### PR TITLE
Fix CI scripts

### DIFF
--- a/ci/cccp_ci.py
+++ b/ci/cccp_ci.py
@@ -111,37 +111,6 @@ def provision(controller):
         host=controller)
 
 
-def wait_for_jenkins_to_come_up_and_trigger_builds(host):
-    cmd = (
-        "ssh -t root@%s curl --head --silent http://localhost:8080/cli/"
-    ) % host
-    retries = 0
-    success = False
-    while retries < 100 and success is False:
-        if retries > 0:
-            time.sleep(10)
-        sys.stdout.write("\nRetries: %d/100" % retries)
-        try:
-            output = subprocess.check_output(cmd, shell=True)
-            sys.stdout.write(output)
-            if output.find('200 OK') >= 0:
-                success = True
-        except subprocess.CalledProcessError:
-            success = False
-        retries += 1
-    if success is False:
-        raise Exception("Jenkins failed to run.")
-    sys.stdout.write("Jenkins is running.")
-
-    # FIXME: currently openshift server cannot handle multiple build request
-    # for the same project at the same time. So, we are not rebuilding
-    # the projects, but just waiting for Jenkins to come up
-    # run_cmd(
-    #    "java -jar /opt/jenkins-cli.jar -s http://localhost:8080/ "
-    #    "build --username admin --password admin cccp-index",
-    #    host=host)
-
-
 def test_if_openshift_builds_are_running(host):
     print "=" * 30
     print "Test if openshift builds are running"
@@ -232,8 +201,6 @@ def run():
     setup_controller(controller)
 
     provision(controller)
-
-    wait_for_jenkins_to_come_up_and_trigger_builds(jenkins_master_host)
 
     test_if_openshift_builds_are_running(jenkins_slave_host)
 

--- a/ci/cccp_ci.py
+++ b/ci/cccp_ci.py
@@ -133,10 +133,13 @@ def wait_for_jenkins_to_come_up_and_trigger_builds(host):
         raise Exception("Jenkins failed to run.")
     sys.stdout.write("Jenkins is running.")
 
-    run_cmd(
-        "java -jar /opt/jenkins-cli.jar -s http://localhost:8080/ "
-        "build --username admin --password admin cccp-index",
-        host=host)
+    # FIXME: currently openshift server cannot handle multiple build request
+    # for the same project at the same time. So, we are not rebuilding
+    # the projects, but just waiting for Jenkins to come up
+    # run_cmd(
+    #    "java -jar /opt/jenkins-cli.jar -s http://localhost:8080/ "
+    #    "build --username admin --password admin cccp-index",
+    #    host=host)
 
 
 def test_if_openshift_builds_are_running(host):

--- a/roles/jenkins/master/tasks/config.yml
+++ b/roles/jenkins/master/tasks/config.yml
@@ -3,8 +3,6 @@
   copy: >
     src="jenkins.conf"
     dest="/etc/sysconfig/jenkins"
-  notify:
-  - restart jenkins
   tags:
   - jenkins
   - jenkins/master
@@ -18,8 +16,6 @@
   - config.xml
   - credentials.xml
 #  - hudson.tasks.Mailer.xml
-  notify:
-  - restart jenkins
   tags:
   - jenkins
   - jenkins/master
@@ -40,8 +36,6 @@
     src="slave-config.xml.j2"
     dest="/var/lib/jenkins/nodes/{{ item.name }}/config.xml"
   with_items: "{{ slaves }}"
-  notify:
-  - restart jenkins
   tags:
   - jenkins
   - jenkins/master
@@ -56,5 +50,3 @@
   - jenkins
   - jenkins/master
   - config
-  notify:
-  - restart jenkins

--- a/roles/jenkins/master/tasks/jobs.yml
+++ b/roles/jenkins/master/tasks/jobs.yml
@@ -17,8 +17,5 @@
 - name: Copy Job template
   template: src=index.yml.j2  dest={{ ansible_env.HOME }}/index.yml
 
-- name: Wait for Jenkins to get ready for jobs
-  pause: seconds=70
-
 - name: Push job to jenkins
   shell: jenkins-jobs --ignore-cache update {{ ansible_env.HOME}}/index.yml

--- a/roles/jenkins/master/tasks/main.yml
+++ b/roles/jenkins/master/tasks/main.yml
@@ -1,13 +1,27 @@
 - include: install.yml
 
 - name: Wait for Jenkins to come up
-  pause: seconds=70 
+  shell: curl --head --silent http://localhost:8080/cli/
+  register: result
+  until: result.stdout.find("200 OK") != -1
+  retries: 50
+  delay: 10
 
 - include: plugins.yml
 
 - include: account.yml
 
 - include: config.yml
+
+- name: restart jenkins
+  service: name=jenkins state=restarted
+
+- name: Wait for Jenkins to come up
+  shell: curl --head --silent http://localhost:8080/cli/
+  register: result
+  until: result.stdout.find("200 OK") != -1
+  retries: 50
+  delay: 10
 
 - include: jobs.yml
   tags:

--- a/roles/jenkins/master/tasks/plugins.yml
+++ b/roles/jenkins/master/tasks/plugins.yml
@@ -29,4 +29,3 @@
     java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix | default('') }}/ install-plugin {{ item }}
     creates=/var/lib/jenkins/plugins/{{ item }}.jpi
   with_items: jenkins_plugins
-  notify: restart jenkins


### PR DESCRIPTION
- [x] In CI script, don't re build jobs, but only wait for Jenkins to come up.
- [x] Move wait for Jenkins to come up from CI scripts to Ansible scripts.
